### PR TITLE
BUILD: Fix the local compilation command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@ OBJ_DIR   = $(BUILD_DIR)/obj
 BIN_DIR   = $(BUILD_DIR)/bin
 
 # Tools
+ifdef AVR_GCC_BIN_DIR
 CC    = $(AVR_GCC_BIN_DIR)/avr-gcc
+else
+CC    = avr-gcc
+endif
 MKDIR = mkdir -p
 
 # Options
@@ -47,7 +51,6 @@ $(BIN_DIR)/test_%: $(TEST_DIR)/test_%.c $(filter-out $(OBJ_DIR)/main.o, $(OBJS))
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(SRC_DIR)/%.h
 	@$(MKDIR) $(OBJ_DIR)
 	$(CC) -c $< -o $@ $(CFLAGS)
-
 
 # Object build rule, .c without header
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c


### PR DESCRIPTION
Running `make` locally was incorrectly resulting in the shell attempting to execute the `/avr-gcc` binary, which likely will not be the name for `avr-gcc` on most systems. This fix adds a conditional check to correct this invocation if `AVR_GCC_BIN_DIR` is not defined in `Makefile`.